### PR TITLE
Limit resource reusing between tests to avoid false alarms

### DIFF
--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/deploymentscanner/DeploymentScannerFixtures.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/deploymentscanner/DeploymentScannerFixtures.java
@@ -29,6 +29,8 @@ public interface DeploymentScannerFixtures {
     String DS_CREATE = Ids.build("ds", "create", Random.name());
     String DS_READ = Ids.build("ds", "read", Random.name());
     String DS_UPDATE = Ids.build("ds", "update", Random.name());
+    String DS_UPDATE_INVALID = Ids.build("ds", "update-invalid", Random.name());
+    String DS_UPDATE_RESET = Ids.build("ds", "update-reset", Random.name());
     String DS_DELETE = Ids.build("ds", "delete", Random.name());
 
     static Address deploymentScannerAddress(String name) {

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/deploymentscanner/DeploymentScannerTest.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/deploymentscanner/DeploymentScannerTest.java
@@ -51,6 +51,8 @@ public class DeploymentScannerTest {
     public static void beforeClass() throws Exception {
         operations.add(deploymentScannerAddress(DS_READ), Values.of(PATH, path(DS_READ)));
         operations.add(deploymentScannerAddress(DS_UPDATE), Values.of(PATH, path(DS_UPDATE)));
+        operations.add(deploymentScannerAddress(DS_UPDATE_INVALID), Values.of(PATH, path(DS_UPDATE_INVALID)));
+        operations.add(deploymentScannerAddress(DS_UPDATE_RESET), Values.of(PATH, path(DS_UPDATE_RESET)));
         operations.add(deploymentScannerAddress(DS_DELETE), Values.of(PATH, path(DS_DELETE)));
     }
 
@@ -59,6 +61,8 @@ public class DeploymentScannerTest {
         operations.removeIfExists(deploymentScannerAddress(DS_CREATE));
         operations.removeIfExists(deploymentScannerAddress(DS_READ));
         operations.removeIfExists(deploymentScannerAddress(DS_UPDATE));
+        operations.removeIfExists(deploymentScannerAddress(DS_UPDATE_INVALID));
+        operations.removeIfExists(deploymentScannerAddress(DS_UPDATE_RESET));
         operations.removeIfExists(deploymentScannerAddress(DS_DELETE));
     }
 
@@ -98,7 +102,7 @@ public class DeploymentScannerTest {
 
     @Test
     public void updateInvalidRelativeTo() throws Exception {
-        table.select(DS_UPDATE);
+        table.select(DS_UPDATE_INVALID);
         form.edit();
         form.text(RELATIVE_TO, "invalid");
         form.save();
@@ -110,7 +114,7 @@ public class DeploymentScannerTest {
 
     @Test
     public void reset() throws Exception {
-        table.select(DS_UPDATE);
+        table.select(DS_UPDATE_RESET);
         crud.reset(deploymentScannerAddress(DS_UPDATE), form);
     }
 

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/InfinispanFixtures.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/InfinispanFixtures.java
@@ -51,7 +51,10 @@ public interface InfinispanFixtures {
 
     String LC_CREATE = Ids.build("lc", "create", Random.name());
     String LC_UPDATE = Ids.build("lc", "update", Random.name());
+    String LC_UPDATE_ATTRIBUTES = Ids.build("lc", "update-attributes", Random.name());
+    String LC_UPDATE_EVICTION = Ids.build("lc", "update-eviction", Random.name());
     String LC_RESET = Ids.build("lc", "reset", Random.name());
+    String LC_RESET_TRANSACTION = Ids.build("lc", "reset-transaction", Random.name());
     String LC_REMOVE = Ids.build("lc", "remove", Random.name());
 
     static Address localCacheAddress(String cacheContainer, String localCache) {

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/LocalCacheTest.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/LocalCacheTest.java
@@ -49,14 +49,20 @@ public class LocalCacheTest {
     public static void beforeClass() throws Exception {
         operations.add(cacheContainerAddress(CC_UPDATE));
         client.apply(new AddLocalCache.Builder(LC_UPDATE).cacheContainer(CC_UPDATE).build());
+        client.apply(new AddLocalCache.Builder(LC_UPDATE_ATTRIBUTES).cacheContainer(CC_UPDATE).build());
+        client.apply(new AddLocalCache.Builder(LC_UPDATE_EVICTION).cacheContainer(CC_UPDATE).build());
         client.apply(new AddLocalCache.Builder(LC_RESET).cacheContainer(CC_UPDATE).build());
+        client.apply(new AddLocalCache.Builder(LC_RESET_TRANSACTION).cacheContainer(CC_UPDATE).build());
         client.apply(new AddLocalCache.Builder(LC_REMOVE).cacheContainer(CC_UPDATE).build());
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
         operations.removeIfExists(localCacheAddress(CC_UPDATE, LC_UPDATE));
+        operations.removeIfExists(localCacheAddress(CC_UPDATE, LC_UPDATE_ATTRIBUTES));
+        operations.removeIfExists(localCacheAddress(CC_UPDATE, LC_UPDATE_EVICTION));
         operations.removeIfExists(localCacheAddress(CC_UPDATE, LC_RESET));
+        operations.removeIfExists(localCacheAddress(CC_UPDATE, LC_RESET_TRANSACTION));
         operations.removeIfExists(localCacheAddress(CC_UPDATE, LC_REMOVE));
         operations.removeIfExists(cacheContainerAddress(CC_UPDATE));
     }
@@ -86,12 +92,12 @@ public class LocalCacheTest {
 
     @Test
     public void updateAttributes() throws Exception {
-        table.select(LC_UPDATE);
+        table.select(LC_UPDATE_ATTRIBUTES);
         tabs.select(Ids.build(Ids.LOCAL_CACHE, Ids.TAB));
         FormFragment form = page.getLocalCacheForm();
 
         String moduleName = Random.name();
-        crud.update(localCacheAddress(CC_UPDATE, LC_UPDATE), form,
+        crud.update(localCacheAddress(CC_UPDATE, LC_UPDATE_ATTRIBUTES), form,
                 f -> {
                     f.text(MODULE, moduleName);
                     f.flip(STATISTICS_ENABLED, true);
@@ -115,11 +121,11 @@ public class LocalCacheTest {
 
     @Test
     public void updateEviction() throws Exception {
-        table.select(LC_UPDATE);
+        table.select(LC_UPDATE_EVICTION);
         tabs.select(Ids.build(Ids.LOCAL_CACHE, Ids.CACHE_COMPONENT_EVICTION, Ids.TAB));
         FormFragment form = page.getEvictionForm();
 
-        crud.update(componentAddress(CC_UPDATE, LC_UPDATE, EVICTION), form,
+        crud.update(componentAddress(CC_UPDATE, LC_UPDATE_EVICTION, EVICTION), form,
                 f -> {
                     f.number(MAX_ENTRIES, 23);
                     f.select(STRATEGY, "LRU");
@@ -241,10 +247,10 @@ public class LocalCacheTest {
 
     @Test
     public void resetTransaction() throws Exception {
-        table.select(LC_RESET);
+        table.select(LC_RESET_TRANSACTION);
         tabs.select(Ids.build(Ids.LOCAL_CACHE, Ids.CACHE_COMPONENT_TRANSACTION, Ids.TAB));
         FormFragment form = page.getTransactionForm();
-        crud.reset(componentAddress(CC_UPDATE, LC_RESET, TRANSACTION), form);
+        crud.reset(componentAddress(CC_UPDATE, LC_RESET_TRANSACTION, TRANSACTION), form);
     }
 
     @Test


### PR DESCRIPTION
...when running the whole test cases. See https://github.com/hal/hal.next/issues/159 for more info.