### PR TITLE
added all profile to work in IntelliJ IDEA, changed repository snapsh…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,6 +290,15 @@
 
     <profiles>
         <profile>
+            <id>all</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>tests</module>
+            </modules>
+        </profile>
+        <profile>
             <id>chrome</id>
             <properties>
                 <browser>chrome</browser>
@@ -362,11 +371,17 @@
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Maven Repository Group</name>
             <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>jboss-snapshots-repository</id>
             <name>JBoss Snapshots Repository</name>
             <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
 </project>

--- a/tests/basic/pom.xml
+++ b/tests/basic/pom.xml
@@ -28,4 +28,13 @@
     <artifactId>hal-testsuite-tests-basic</artifactId>
     <name>HAL Testsuite :: Tests :: Basic</name>
     <description>Basic tests</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -24,6 +24,12 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
+    <modules>
+        <module>basic</module>
+        <module>rbac</module>
+        <module>transaction</module>
+    </modules>
+
     <artifactId>hal-testsuite-tests</artifactId>
     <name>HAL Testsuite :: Tests</name>
     <description>Parent POM for all tests</description>
@@ -79,6 +85,26 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>default-jar</id>
+                            <phase>none</phase>
+                        </execution>
+                        <execution>
+                            <id>test-jar</id>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tests/rbac/pom.xml
+++ b/tests/rbac/pom.xml
@@ -28,4 +28,13 @@
     <artifactId>hal-testsuite-tests-rbac</artifactId>
     <name>HAL Testsuite :: Tests :: RBAC</name>
     <description>RBAC tests</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tests/transaction/pom.xml
+++ b/tests/transaction/pom.xml
@@ -28,4 +28,13 @@
     <artifactId>hal-testsuite-tests-transaction</artifactId>
     <name>HAL Testsuite :: Tests :: Transaction</name>
     <description>Transaction tests</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
This PR is a combination of solutions for these issues: #14 #15 #16. When ticking the ``all`` profile in the ``Maven Projects`` window, project layout is visualized as expected. Setting the ``<snapshots>`` configuration in the repositories solves the problem of the timestamped ``SNAPSHOT`` version issue. Disabling the ``default-jar`` goal of the ``maven-jar-plugin`` results in no excessive warnings in the build and the ``test-jar`` goal is introduced as ``tests/basic``, ``tests/rbac``, ``tests/transactions`` contain only test code. 