### PR TITLE
EAP7-1062: Add test for microprofile health check

### DIFF
--- a/common/src/main/java/org/jboss/hal/testsuite/fragment/AlertFragment.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/fragment/AlertFragment.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.hal.testsuite.fragment;
+
+import org.jboss.arquillian.graphene.fragment.Root;
+import org.openqa.selenium.WebElement;
+
+import static org.jboss.hal.resources.CSS.alertDanger;
+import static org.jboss.hal.resources.CSS.alertInfo;
+import static org.jboss.hal.resources.CSS.alertSuccess;
+import static org.jboss.hal.resources.CSS.alertWarning;
+
+public class AlertFragment {
+
+    @Root private WebElement root;
+
+    public boolean isSuccess() {
+        return hasClass(alertSuccess);
+    }
+
+    public boolean isInfo() {
+        return hasClass(alertInfo);
+    }
+
+    public boolean isWarning() {
+        return hasClass(alertWarning);
+    }
+
+    public boolean isError() {
+        return hasClass(alertDanger);
+    }
+
+    private boolean hasClass(String expected) {
+        String cssClass = root.getAttribute("class");
+        return cssClass != null && cssClass.contains(expected);
+    }
+}

--- a/common/src/main/java/org/jboss/hal/testsuite/fragment/finder/FinderPreviewFragment.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/fragment/finder/FinderPreviewFragment.java
@@ -22,13 +22,15 @@ import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.findby.ByJQuery;
 import org.jboss.arquillian.graphene.fragment.Root;
 import org.jboss.hal.testsuite.Console;
+import org.jboss.hal.testsuite.fragment.AlertFragment;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import static java.util.stream.Collectors.toMap;
-
+import static org.jboss.arquillian.graphene.Graphene.createPageFragment;
 import static org.jboss.arquillian.graphene.Graphene.waitGui;
+import static org.jboss.hal.resources.CSS.alert;
 import static org.jboss.hal.resources.CSS.key;
 import static org.jboss.hal.resources.CSS.listGroup;
 import static org.jboss.hal.resources.CSS.value;
@@ -42,6 +44,10 @@ public class FinderPreviewFragment {
     private WebElement root;
     @Inject
     private Console console;
+
+    public AlertFragment getAlert() {
+        return createPageFragment(AlertFragment.class, root.findElement(By.className(alert)));
+    }
 
     public Map<String, String> getMainAttributes() {
         return getMainAttributesElements().entrySet()

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/systemproperty/SystemPropertyFixtures.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/systemproperty/SystemPropertyFixtures.java
@@ -20,28 +20,22 @@ import org.jboss.hal.testsuite.CrudConstants;
 import org.jboss.hal.testsuite.Random;
 import org.wildfly.extras.creaper.core.online.operations.Address;
 
+import static org.jboss.hal.dmr.ModelDescriptionConstants.NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE;
 
-public final class SystemPropertyFixtures {
+public interface SystemPropertyFixtures {
 
-    private static final String SYSTEM_PROPERTY_PREFIX = "sp";
-    private static final String NAME = "name";
-    private static final String VALUE = "value";
+    String CREATE_NAME = Ids.build(SYSTEM_PROPERTY, CrudConstants.CREATE, NAME, Random.name());
+    String CREATE_VALUE = Ids.build(SYSTEM_PROPERTY, CrudConstants.CREATE, VALUE, Random.name());
+    String READ_NAME = Ids.build(SYSTEM_PROPERTY, CrudConstants.READ, NAME, Random.name());
+    String READ_VALUE = Ids.build(SYSTEM_PROPERTY, CrudConstants.READ, VALUE, Random.name());
+    String UPDATE_NAME = Ids.build(SYSTEM_PROPERTY, CrudConstants.UPDATE, NAME, Random.name());
+    String UPDATE_VALUE = Ids.build(SYSTEM_PROPERTY, CrudConstants.UPDATE, VALUE, Random.name());
+    String DELETE_NAME = Ids.build(SYSTEM_PROPERTY, CrudConstants.DELETE, NAME, Random.name());
+    String DELETE_VALUE = Ids.build(SYSTEM_PROPERTY, CrudConstants.DELETE, VALUE, Random.name());
 
-    static final String CREATE_NAME = Ids.build(SYSTEM_PROPERTY_PREFIX, CrudConstants.CREATE, NAME, Random.name());
-    static final String CREATE_VALUE = Ids.build(SYSTEM_PROPERTY_PREFIX, CrudConstants.CREATE, VALUE, Random.name());
-    static final String READ_NAME = Ids.build(SYSTEM_PROPERTY_PREFIX, CrudConstants.READ, NAME, Random.name());
-    static final String READ_VALUE = Ids.build(SYSTEM_PROPERTY_PREFIX, CrudConstants.READ, VALUE, Random.name());
-    static final String UPDATE_NAME = Ids.build(SYSTEM_PROPERTY_PREFIX, CrudConstants.UPDATE, NAME, Random.name());
-    static final String UPDATE_VALUE = Ids.build(SYSTEM_PROPERTY_PREFIX, CrudConstants.UPDATE, VALUE, Random.name());
-    static final String DELETE_NAME = Ids.build(SYSTEM_PROPERTY_PREFIX, CrudConstants.DELETE, NAME, Random.name());
-    static final String DELETE_VALUE = Ids.build(SYSTEM_PROPERTY_PREFIX, CrudConstants.DELETE, VALUE, Random.name());
-
-    public static Address systemPropertyAddress(String name) {
+    static Address systemPropertyAddress(String name) {
         return Address.of(SYSTEM_PROPERTY, name);
-    }
-
-    private SystemPropertyFixtures() {
-
     }
 }

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/systemproperty/SystemPropertyTest.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/systemproperty/SystemPropertyTest.java
@@ -53,10 +53,14 @@ public class SystemPropertyTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        operations.removeIfExists(systemPropertyAddress(CREATE_NAME));
-        operations.removeIfExists(systemPropertyAddress(READ_NAME));
-        operations.removeIfExists(systemPropertyAddress(UPDATE_NAME));
-        operations.removeIfExists(systemPropertyAddress(DELETE_NAME));
+        try {
+            operations.removeIfExists(systemPropertyAddress(CREATE_NAME));
+            operations.removeIfExists(systemPropertyAddress(READ_NAME));
+            operations.removeIfExists(systemPropertyAddress(UPDATE_NAME));
+            operations.removeIfExists(systemPropertyAddress(DELETE_NAME));
+        } finally {
+            client.close();
+        }
     }
 
     @Inject private CrudOperations crud;

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/microprofile/health/MicroProfileHealthCheckTest.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/microprofile/health/MicroProfileHealthCheckTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.hal.testsuite.test.runtime.microprofile.health;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.hal.meta.token.NameTokens;
+import org.jboss.hal.resources.Ids;
+import org.jboss.hal.testsuite.Console;
+import org.jboss.hal.testsuite.category.Standalone;
+import org.jboss.hal.testsuite.creaper.ManagementClientProvider;
+import org.jboss.hal.testsuite.fragment.finder.ColumnFragment;
+import org.jboss.hal.testsuite.fragment.finder.FinderFragment;
+import org.jboss.hal.testsuite.util.ServerEnvironmentUtils;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+
+import static org.jboss.hal.dmr.ModelDescriptionConstants.MICROPROFILE_HEALTH_SMALLRYE;
+import static org.jboss.hal.testsuite.fragment.finder.FinderFragment.runtimeSubsystemPath;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+@Category(Standalone.class)
+public class MicroProfileHealthCheckTest {
+
+    private static final OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient();
+    private static final ServerEnvironmentUtils serverEnvironmentUtils = new ServerEnvironmentUtils(client);
+
+    @Inject private Console console;
+
+    @Test
+    public void checkUp() throws IOException {
+        FinderFragment finder = console.finder(NameTokens.RUNTIME,
+                runtimeSubsystemPath(serverEnvironmentUtils.getServerHostName(), MICROPROFILE_HEALTH_SMALLRYE));
+        ColumnFragment column = finder.column(Ids.RUNTIME_SUBSYSTEM);
+        column.selectItem(MICROPROFILE_HEALTH_SMALLRYE); // we only get a preview in this case if we select the item
+        assertTrue(finder.preview().getAlert().isSuccess());
+    }
+}


### PR DESCRIPTION
Upstream issue: https://issues.jboss.org/browse/HAL-1543
EAP7 issue: https://issues.jboss.org/browse/EAP7-1062

Adds a test which selects the micro-profile health check in runtime and checks that the status is successful. Works only for standalone mode.