### PR TITLE
[WFLY-12115] - Console shows server URL as n/a if http is disabled

### DIFF
--- a/common/src/main/java/org/jboss/hal/testsuite/fragment/finder/LogFilePreviewFragment.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/fragment/finder/LogFilePreviewFragment.java
@@ -1,0 +1,20 @@
+package org.jboss.hal.testsuite.fragment.finder;
+
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.findby.FindByJQuery;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class LogFilePreviewFragment extends FinderPreviewFragment {
+
+    @Drone
+    private WebDriver browser;
+
+    @FindByJQuery(".log-file-preview")
+    private WebElement preview;
+
+    public String preview() {
+        return preview.getText();
+    }
+
+}

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/DeploymentDrone.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/DeploymentDrone.java
@@ -1,4 +1,4 @@
-package org.jboss.hal.testsuite.test.runtime.undertow;
+package org.jboss.hal.testsuite.test;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/datasource/NonXADatasourceCreateTest.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/datasource/NonXADatasourceCreateTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2015-2019 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.hal.testsuite.test.configuration.datasource;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.hal.meta.token.NameTokens;
+import org.jboss.hal.resources.Ids;
+import org.jboss.hal.resources.Names;
+import org.jboss.hal.testsuite.Console;
+import org.jboss.hal.testsuite.Random;
+import org.jboss.hal.testsuite.fragment.FormFragment;
+import org.jboss.hal.testsuite.fragment.WizardFragment;
+import org.jboss.hal.testsuite.fragment.finder.ColumnFragment;
+import org.jboss.hal.testsuite.test.configuration.datasource.properties.AbstractDatasourcePropertiesTest;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
+
+import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
+import static org.jboss.hal.testsuite.fragment.finder.FinderFragment.configurationSubsystemPath;
+import static org.junit.Assert.assertEquals;
+
+
+@RunWith(Arquillian.class)
+public class NonXADatasourceCreateTest extends AbstractDatasourcePropertiesTest {
+    private static final String POSTGRESQL_CSS_SELECTOR = "input[type=radio][name=template][value=postgresql]";
+    private static final String SQLSERVER_CSS_SELECTOR = "input[type=radio][name=template][value=sqlserver]";
+    private static final String PG_DATASOURCE_NAME = "postgresql-data-source-create-" + Random.name();
+    private static final String SQLSERVER_DATASOURCE_NAME = "sqlserver-data-source-create-" + Random.name();
+
+    @Drone
+    private WebDriver browser;
+    @Inject private Console console;
+    private ColumnFragment column;
+    private WizardFragment wizard;
+
+    @Before
+    public void navigateToCreateXADatasourceWizard() {
+        column = console.finder(NameTokens.CONFIGURATION, configurationSubsystemPath(DATASOURCES)
+                .append(Ids.DATA_SOURCE_DRIVER, Ids.asId(Names.DATASOURCES)))
+                .column(Ids.DATA_SOURCE_CONFIGURATION);
+        column.dropdownAction(Ids.DATA_SOURCE_ADD_ACTIONS, Ids.DATA_SOURCE_ADD);
+        wizard = console.wizard();
+    }
+
+    @AfterClass
+    public static void cleanUpDataSources() throws InterruptedException, TimeoutException, IOException, OperationException {
+        operations.removeIfExists(DataSourceFixtures.dataSourceAddress(PG_DATASOURCE_NAME));
+        operations.removeIfExists(DataSourceFixtures.dataSourceAddress(SQLSERVER_DATASOURCE_NAME));
+        administration.reloadIfRequired();
+    }
+
+    /** Create a data source for postgresql */
+    @Test
+    public void createPostgreSQLDataSources() throws Exception {
+        wizard.getRoot().findElement(By.cssSelector(POSTGRESQL_CSS_SELECTOR)).click();
+        wizard.next(Ids.DATA_SOURCE_NAMES_FORM);
+        FormFragment namesForms = wizard.getForm(Ids.DATA_SOURCE_NAMES_FORM);
+        namesForms.text(NAME, PG_DATASOURCE_NAME);
+        wizard.next(Ids.DATA_SOURCE_DRIVER_FORM);
+        FormFragment driverForm = wizard.getForm(Ids.DATA_SOURCE_DRIVER_FORM);
+        driverForm.text(DRIVER_NAME, PG_DRIVER_NAME);
+        driverForm.text(DRIVER_CLASS_NAME, "");
+        driverForm.clear(DRIVER_CLASS_NAME);
+        wizard.next(Ids.DATA_SOURCE_CONNECTION_FORM);
+        wizard.next(Ids.DATA_SOURCE_TEST_CONNECTION);
+        wizard.next(Ids.DATA_SOURCE_REVIEW_FORM);
+
+        assertEquals("", driverForm.value(DRIVER_CLASS_NAME));
+        wizard.finishStayOpen();
+        wizard.verifySuccess();
+        wizard.close();
+        assertEquals("Bad value of field " + DATASOURCE_CLASS + " in configuration file!","",operations.readAttribute(DataSourceFixtures.dataSourceAddress(PG_DATASOURCE_NAME), DATASOURCE_CLASS).stringValue());
+    }
+
+    /** Create a data source for sqlserver */
+    @Test
+    public void createSqlserverDataSources() throws Exception {
+        wizard.getRoot().findElement(By.cssSelector(SQLSERVER_CSS_SELECTOR)).click();
+        wizard.next(Ids.DATA_SOURCE_NAMES_FORM);
+        FormFragment namesForms = wizard.getForm(Ids.DATA_SOURCE_NAMES_FORM);
+        namesForms.text(NAME, SQLSERVER_DATASOURCE_NAME);
+        wizard.next(Ids.DATA_SOURCE_DRIVER_FORM);
+        FormFragment driverForm = wizard.getForm(Ids.DATA_SOURCE_DRIVER_FORM);
+        driverForm.text(DRIVER_NAME, MSSQL_DRIVER_NAME);
+        driverForm.text(DRIVER_CLASS_NAME, "");
+        driverForm.clear(DRIVER_CLASS_NAME);
+        wizard.next(Ids.DATA_SOURCE_CONNECTION_FORM);
+        wizard.next(Ids.DATA_SOURCE_TEST_CONNECTION);
+        wizard.next(Ids.DATA_SOURCE_REVIEW_FORM);
+
+        assertEquals("", driverForm.value(DRIVER_CLASS_NAME));
+        wizard.finishStayOpen();
+        wizard.verifySuccess();
+        wizard.close();
+        assertEquals("Bad value of field " + DATASOURCE_CLASS + " in configuration file!","",operations.readAttribute(DataSourceFixtures.dataSourceAddress(SQLSERVER_DATASOURCE_NAME), DATASOURCE_CLASS).stringValue());
+    }
+}

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/datasource/NonXADatasourceCreateTest.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/datasource/NonXADatasourceCreateTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.wildfly.extras.creaper.core.online.ModelNodeResult;
 import org.wildfly.extras.creaper.core.online.operations.OperationException;
 
 import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
@@ -92,7 +93,8 @@ public class NonXADatasourceCreateTest extends AbstractDatasourcePropertiesTest 
         wizard.finishStayOpen();
         wizard.verifySuccess();
         wizard.close();
-        assertEquals("Bad value of field " + DATASOURCE_CLASS + " in configuration file!","",operations.readAttribute(DataSourceFixtures.dataSourceAddress(PG_DATASOURCE_NAME), DATASOURCE_CLASS).stringValue());
+        ModelNodeResult result = operations.readAttribute(DataSourceFixtures.dataSourceAddress(PG_DATASOURCE_NAME), DATASOURCE_CLASS);
+        assertEquals("Bad value of field " + DATASOURCE_CLASS + " in configuration file!","undefined",operations.readAttribute(DataSourceFixtures.dataSourceAddress(PG_DATASOURCE_NAME), DATASOURCE_CLASS).value().asString());
     }
 
     /** Create a data source for sqlserver */
@@ -115,6 +117,6 @@ public class NonXADatasourceCreateTest extends AbstractDatasourcePropertiesTest 
         wizard.finishStayOpen();
         wizard.verifySuccess();
         wizard.close();
-        assertEquals("Bad value of field " + DATASOURCE_CLASS + " in configuration file!","",operations.readAttribute(DataSourceFixtures.dataSourceAddress(SQLSERVER_DATASOURCE_NAME), DATASOURCE_CLASS).stringValue());
+        assertEquals("Bad value of field " + DATASOURCE_CLASS + " in configuration file!","undefined",operations.readAttribute(DataSourceFixtures.dataSourceAddress(SQLSERVER_DATASOURCE_NAME), DATASOURCE_CLASS).value().asString());
     }
 }

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/InfinispanFixtures.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/InfinispanFixtures.java
@@ -106,6 +106,10 @@ public final class InfinispanFixtures {
         return cacheContainerAddress(cacheContainer).and("local-cache", localCache);
     }
 
+    public static Address distributedCacheAddress(String cacheContainer, String distributedCache) {
+        return cacheContainerAddress(cacheContainer).and("distributed-cache", distributedCache);
+    }
+
     public static Address scatteredCacheAddress(String cacheContainer, String scatteredCache) {
         return cacheContainerAddress(cacheContainer).and("scattered-cache", scatteredCache);
     }

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/cache/container/distributed/cache/DistributedCacheFinderTest.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/cache/container/distributed/cache/DistributedCacheFinderTest.java
@@ -1,0 +1,90 @@
+package org.jboss.hal.testsuite.test.configuration.infinispan.cache.container.distributed.cache;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.hal.meta.token.NameTokens;
+import org.jboss.hal.resources.Ids;
+import org.jboss.hal.testsuite.Console;
+import org.jboss.hal.testsuite.Random;
+import org.jboss.hal.testsuite.creaper.ManagementClientProvider;
+import org.jboss.hal.testsuite.creaper.ResourceVerifier;
+import org.jboss.hal.testsuite.fragment.AddResourceDialogFragment;
+import org.jboss.hal.testsuite.fragment.finder.ColumnFragment;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+import static org.jboss.hal.dmr.ModelDescriptionConstants.INFINISPAN;
+import static org.jboss.hal.testsuite.fragment.finder.FinderFragment.configurationSubsystemPath;
+import static org.jboss.hal.testsuite.test.configuration.infinispan.InfinispanFixtures.cacheContainerAddress;
+import static org.jboss.hal.testsuite.test.configuration.infinispan.InfinispanFixtures.distributedCacheAddress;
+
+@RunWith(Arquillian.class)
+public class DistributedCacheFinderTest {
+
+    private static final OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient();
+    private static final Operations operations = new Operations(client);
+    private static final Administration administration = new Administration(client);
+
+    private static final String CACHE_CONTAINER = "cache-container-" + Random.name();
+    private static final String DISTRIBUTED_CACHE_CREATE = "distributed-cache-create-" + Random.name();
+
+    @BeforeClass
+    public static void setUp() throws IOException, TimeoutException, InterruptedException {
+        operations.add(cacheContainerAddress(CACHE_CONTAINER));
+        administration.reloadIfRequired();
+    }
+
+    @AfterClass
+    public static void tearDown() throws IOException, OperationException {
+        try {
+            operations.removeIfExists(cacheContainerAddress(CACHE_CONTAINER));
+        } finally {
+            client.close();
+        }
+    }
+
+    @Drone
+    private WebDriver browser;
+
+    @Inject
+    private Console console;
+
+    private ColumnFragment cacheColumn;
+
+    @Before
+    public void initPage() {
+        cacheColumn = console.finder(NameTokens.CONFIGURATION,
+                configurationSubsystemPath(INFINISPAN).append(Ids.CACHE_CONTAINER, Ids.cacheContainer(CACHE_CONTAINER)))
+                .column("cache");
+    }
+
+    @Test
+    public void create() throws Exception {
+        cacheColumn.dropdownAction("cache-add-actions", "distributed-cache-add");
+        AddResourceDialogFragment addResourceDialogFragment = console.addResourceDialog();
+        addResourceDialogFragment.getForm().text("name", DISTRIBUTED_CACHE_CREATE);
+        addResourceDialogFragment.add();
+        console.verifySuccess();
+        Assert.assertTrue("Newly created distributed cache should be present in the cache column",
+                cacheColumn.containsItem(distributedCacheId(DISTRIBUTED_CACHE_CREATE)));
+        new ResourceVerifier(distributedCacheAddress(CACHE_CONTAINER, DISTRIBUTED_CACHE_CREATE), client).verifyExists();
+    }
+
+    private static String distributedCacheId(String distributedCacheName) {
+        return Ids.build("distributed-cache", distributedCacheName);
+    }
+
+}

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/io/UrlConnectionTestCase.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/io/UrlConnectionTestCase.java
@@ -1,0 +1,131 @@
+package org.jboss.hal.testsuite.test.runtime.io;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.hal.meta.token.NameTokens;
+import org.jboss.hal.resources.Ids;
+import org.jboss.hal.testsuite.Console;
+import org.jboss.hal.testsuite.category.Domain;
+import org.jboss.hal.testsuite.creaper.ManagementClientProvider;
+import org.jboss.hal.testsuite.creaper.command.BackupAndRestoreAttributes;
+import org.jboss.hal.testsuite.fragment.finder.FinderFragment;
+import org.jboss.hal.testsuite.fragment.finder.FinderPath;
+import org.jboss.hal.testsuite.fragment.finder.ItemFragment;
+import org.jboss.hal.testsuite.fragment.finder.ServerPreviewFragment;
+import org.jboss.hal.testsuite.util.ConfigUtils;
+import org.jboss.hal.testsuite.util.ServerEnvironmentUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.Batch;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.core.online.operations.Values;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+
+
+@RunWith(Arquillian.class)
+@Category(Domain.class)
+public class UrlConnectionTestCase {
+    private static final String SERVER_GROUP = "server-group";
+    private static final String PROFILE = "profile";
+    private static final String DEFAULT = "default";
+
+    private static final OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient();
+    private static final ServerEnvironmentUtils serverEnvironmentUtils = new ServerEnvironmentUtils(client);
+    private static final Operations operations = new Operations(client);
+
+    private static final Address hostMaster = Address.of("host","master");
+    private static final Address serverGroupMain = Address.of(SERVER_GROUP,"main-server-group");
+
+    private static final BackupAndRestoreAttributes backupHost = new BackupAndRestoreAttributes.Builder(hostMaster).build();
+    private static final BackupAndRestoreAttributes backupOtherServerGroup = new BackupAndRestoreAttributes.Builder(Address.of(SERVER_GROUP,"other-server-group")).build();
+    private static final BackupAndRestoreAttributes backupMainServerGroup = new BackupAndRestoreAttributes.Builder(Address.of(SERVER_GROUP,"main-server-group")).build();
+    private static final BackupAndRestoreAttributes backupProfile = new BackupAndRestoreAttributes.Builder(Address.of(PROFILE, DEFAULT)).build();
+    private static final Administration administration = new Administration(client);
+
+    @BeforeClass
+    public static void setUp() throws IOException, TimeoutException, InterruptedException {
+        backupHost.backup();
+        backupOtherServerGroup.backup();
+        backupMainServerGroup.backup();
+        backupProfile.backup();
+
+        operations.batch(new Batch().remove(hostMaster.and("server-config","server-three"))); // /host=master/server-config=server-three:remove()
+        operations.batch(new Batch().remove(Address.of(SERVER_GROUP,"other-server-group")));                  // /server-group=other-server-group:remove()
+
+        operations.batch(new Batch().add(serverGroupMain, Values.of(PROFILE, DEFAULT)));
+        operations.batch(new Batch().writeAttribute(serverGroupMain,PROFILE, DEFAULT));
+
+        operations.batch(new Batch().writeAttribute(serverGroupMain,"socket-binding-group","standard-sockets"));
+
+        operations.batch(new Batch().remove(Address.of(PROFILE,DEFAULT).and("subsystem","undertow").and("server","default-server").and("http-listener","default")));
+        operations.batch(new Batch().writeAttribute(serverGroupMain.and("jvm",DEFAULT),"heap-size", "256m"));
+        operations.batch(new Batch().writeAttribute(serverGroupMain.and("jvm",DEFAULT),"max-heap-size", "256m"));
+
+        administration.reloadIfRequired();
+
+    }
+    @AfterClass
+    public static void tearDown()
+            throws IOException, InterruptedException, TimeoutException {
+        try {
+            backupHost.restore();
+            backupOtherServerGroup.restore();
+            backupMainServerGroup.restore();
+            backupProfile.restore();
+            administration.reloadIfRequired();
+        } finally {
+            client.close();
+        }
+    }
+
+
+    @Drone
+    private WebDriver browser;
+
+    @Inject
+    private Console console;
+
+    @Test
+    public void testUrlHttps() throws IOException {
+        FinderFragment fragment = getMainAttributesFinder();
+        selectServer(fragment);
+        ServerPreviewFragment serverPreviewFragment = fragment.preview(ServerPreviewFragment.class);
+        if (!serverPreviewFragment.getUrlAttributeItem().getValueElement().getText().contains("https")) {
+            Assert.fail("URL should contain https! See WFLY-12115");
+        }
+    }
+
+    private FinderFragment getMainAttributesFinder() {
+        FinderFragment fragment;
+        if (ConfigUtils.isDomain()) {
+            fragment = console.finder(NameTokens.RUNTIME, new FinderPath()
+                    .append(Ids.DOMAIN_BROWSE_BY, "hosts")
+                    .append(Ids.HOST, Ids.build("host", ConfigUtils.getDefaultHost())));
+        } else {
+            fragment = console.finder(NameTokens.RUNTIME);
+        }
+        return fragment;
+    }
+
+    private ItemFragment selectServer(FinderFragment fragment) throws IOException {
+        if (ConfigUtils.isDomain()) {
+            return fragment.column(Ids.SERVER)
+                    .selectItem(Ids.build(ConfigUtils.getDefaultHost(), ConfigUtils.getDefaultServer()));
+        } else {
+            return fragment.column(Ids.STANDALONE_SERVER_COLUMN)
+                    .selectItem("standalone-host-" + serverEnvironmentUtils.getServerHostName());
+        }
+    }
+}

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/logging/ViewLogFromLoggingProfileTest.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/logging/ViewLogFromLoggingProfileTest.java
@@ -1,0 +1,86 @@
+package org.jboss.hal.testsuite.test.runtime.logging;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.page.Page;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.hal.testsuite.Console;
+import org.jboss.hal.testsuite.Random;
+import org.jboss.hal.testsuite.creaper.ManagementClientProvider;
+import org.jboss.hal.testsuite.page.configuration.LoggingSubsystemConfigurationPage;
+import org.jboss.hal.testsuite.test.configuration.logging.LoggingFixtures;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+import org.wildfly.extras.creaper.commands.deployments.Deploy;
+import org.wildfly.extras.creaper.commands.deployments.Undeploy;
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+
+@RunWith(Arquillian.class)
+public class ViewLogFromLoggingProfileTest {
+
+    private static final OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient();
+    private static final Operations operations = new Operations(client);
+    private static String deploymentName;
+
+    private static final String LOGGING_PROFILE = "logging-profile-" + Random.name();
+
+    @ClassRule
+    public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @BeforeClass
+    public static void setUp() throws IOException, CommandFailedException {
+        WebArchive archive = EmbeddedMaven.forProject(ViewLogFromLoggingProfileTest.class.getResource("pom.xml").getFile())
+            .addProperty("loggingProfile", LOGGING_PROFILE).setGoals("package").build().getDefaultBuiltArchive()
+            .as(WebArchive.class);
+        deploymentName = archive.getName();
+        File archiveFile = temporaryFolder.newFile(deploymentName);
+        archive.as(ZipExporter.class).exportTo(archiveFile, true);
+        Deploy deploy = new Deploy.Builder(archiveFile).build();
+        operations.add(LoggingFixtures.LoggingProfile.loggingProfileAddress(LOGGING_PROFILE));
+        client.apply(deploy);
+    }
+
+    @AfterClass
+    public static void tearDown() throws IOException, OperationException, CommandFailedException {
+        try {
+            Undeploy undeploy = new Undeploy.Builder(deploymentName).build();
+            client.apply(undeploy);
+            operations.removeIfExists(LoggingFixtures.LoggingProfile.loggingProfileAddress(LOGGING_PROFILE));
+        } finally {
+            client.close();
+        }
+    }
+
+    @Drone
+    private WebDriver browser;
+
+    @Inject
+    private Console console;
+
+    @Page
+    private LoggingSubsystemConfigurationPage page;
+
+    @Test
+    public void test() {
+        page.navigate();
+        Assert.assertTrue(true);
+        System.out.println("Woohoo");
+    }
+
+
+}

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/logging/ViewLogFromLoggingProfileTest.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/logging/ViewLogFromLoggingProfileTest.java
@@ -5,13 +5,20 @@ import java.io.IOException;
 
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.drone.api.annotation.Drone;
-import org.jboss.arquillian.graphene.page.Page;
+import org.jboss.arquillian.drone.api.annotation.lifecycle.MethodLifecycle;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.dmr.ModelNode;
+import org.jboss.hal.meta.token.NameTokens;
 import org.jboss.hal.testsuite.Console;
 import org.jboss.hal.testsuite.Random;
 import org.jboss.hal.testsuite.creaper.ManagementClientProvider;
-import org.jboss.hal.testsuite.page.configuration.LoggingSubsystemConfigurationPage;
+import org.jboss.hal.testsuite.dmr.ModelNodeGenerator;
+import org.jboss.hal.testsuite.fragment.finder.ColumnFragment;
+import org.jboss.hal.testsuite.fragment.finder.FinderFragment;
+import org.jboss.hal.testsuite.fragment.finder.LogFilePreviewFragment;
+import org.jboss.hal.testsuite.test.DeploymentDrone;
 import org.jboss.hal.testsuite.test.configuration.logging.LoggingFixtures;
+import org.jboss.hal.testsuite.util.ServerEnvironmentUtils;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
@@ -22,6 +29,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.wildfly.extras.creaper.commands.deployments.Deploy;
 import org.wildfly.extras.creaper.commands.deployments.Undeploy;
@@ -29,29 +37,44 @@ import org.wildfly.extras.creaper.core.CommandFailedException;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.operations.OperationException;
 import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.core.online.operations.Values;
 
 @RunWith(Arquillian.class)
 public class ViewLogFromLoggingProfileTest {
 
     private static final OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient();
     private static final Operations operations = new Operations(client);
+    private static final ServerEnvironmentUtils serverEnvironmentUtils = new ServerEnvironmentUtils(client);
     private static String deploymentName;
 
     private static final String LOGGING_PROFILE = "logging-profile-" + Random.name();
+    private static final String FILE_HANDLER = "file-handler-" + Random.name();
+    private static final String LOG_FILE = "log-file-" + Random.name() + ".log";
+    private static String deploymentUrl;
 
     @ClassRule
     public static TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @BeforeClass
     public static void setUp() throws IOException, CommandFailedException {
-        WebArchive archive = EmbeddedMaven.forProject(ViewLogFromLoggingProfileTest.class.getResource("pom.xml").getFile())
-            .addProperty("loggingProfile", LOGGING_PROFILE).setGoals("package").build().getDefaultBuiltArchive()
-            .as(WebArchive.class);
+        WebArchive archive =
+            EmbeddedMaven.forProject(ViewLogFromLoggingProfileTest.class.getResource("pom.xml").getFile())
+                .addProperty("loggingProfile", LOGGING_PROFILE).setGoals("package").build().getDefaultBuiltArchive()
+                .as(WebArchive.class);
         deploymentName = archive.getName();
+        deploymentUrl = String.format("http://%s:8080/%s", System.getProperty("as.managementAddress", "localhost"),
+            deploymentName.replaceAll("\\.war", ""));
         File archiveFile = temporaryFolder.newFile(deploymentName);
         archive.as(ZipExporter.class).exportTo(archiveFile, true);
         Deploy deploy = new Deploy.Builder(archiveFile).build();
-        operations.add(LoggingFixtures.LoggingProfile.loggingProfileAddress(LOGGING_PROFILE));
+        ModelNode file = new ModelNodeGenerator.ModelNodePropertiesBuilder().addProperty("path", LOG_FILE)
+            .addProperty("relative-to", "jboss.server.log.dir").build();
+        operations.add(LoggingFixtures.LoggingProfile.loggingProfileAddress(LOGGING_PROFILE)).assertSuccess();
+        operations.add(LoggingFixtures.LoggingProfile.fileHandlerAddress(LOGGING_PROFILE, FILE_HANDLER),
+            Values.of("file", file).and("level", "ALL")).assertSuccess();
+        operations.add(LoggingFixtures.LoggingProfile.rootLoggerAddress(LOGGING_PROFILE),
+            Values.of("handlers", new ModelNodeGenerator.ModelNodeListBuilder()
+                .addAll(FILE_HANDLER).build()).and("level", "ALL")).assertSuccess();
         client.apply(deploy);
     }
 
@@ -66,21 +89,66 @@ public class ViewLogFromLoggingProfileTest {
         }
     }
 
+    private static String logFileItemId(String logFile) {
+        return logFile.replaceAll("\\.log", "log");
+    }
+
     @Drone
     private WebDriver browser;
+
+    @Drone
+    @DeploymentDrone
+    @MethodLifecycle
+    private WebDriver deploymentBrowser;
 
     @Inject
     private Console console;
 
-    @Page
-    private LoggingSubsystemConfigurationPage page;
+    private FinderFragment finder;
 
-    @Test
-    public void test() {
-        page.navigate();
-        Assert.assertTrue(true);
-        System.out.println("Woohoo");
+    private ColumnFragment column;
+
+    public void getColumn() throws IOException {
+        finder = console.finder(NameTokens.RUNTIME,
+            FinderFragment.runtimeSubsystemPath(serverEnvironmentUtils.getServerHostName(), "logging"));
+        column = finder.column("lf");
     }
 
+    @Test
+    public void verifyLoggingProfileIsPresentInColumn() throws IOException {
+        getColumn();
+        Assert.assertTrue("Regular log files should be present in the column alongside log files from logging profiles",
+            column.containsItem(logFileItemId("server.log")));
+        Assert.assertTrue("Logging profile's log file should be present in the column",
+            column.containsItem(logFileItemId(LOG_FILE)));
+    }
 
+    @Test
+    public void verifyLogFileNameIsHeader() throws IOException {
+        getColumn();
+        String header = column.selectItem(logFileItemId(LOG_FILE)).getRoot()
+            .findElement(By.cssSelector(".item-text > span"))
+            .getText();
+        Assert.assertEquals("Logging profile's log file should be header of column's item", LOG_FILE, header);
+    }
+
+    @Test
+    public void verifyLoggingProfileIsColumnsSubtitle() throws IOException {
+        getColumn();
+        String subtitle = column.selectItem(logFileItemId(LOG_FILE)).getRoot()
+            .findElement(By.cssSelector(".item-text > .subtitle"))
+            .getText();
+        Assert.assertEquals("Logging profile should be the subtitle of column's item", LOGGING_PROFILE, subtitle);
+    }
+
+    @Test
+    public void verifyLoggingProfileIsInPreview() throws IOException {
+        deploymentBrowser.get(deploymentUrl);
+        getColumn();
+        column.selectItem(logFileItemId(LOG_FILE));
+        LogFilePreviewFragment logFilePreview = finder.preview(LogFilePreviewFragment.class);
+        Assert.assertEquals("Logging profile should be present in the \"Main Attributes\" of the log file",
+            LOGGING_PROFILE, logFilePreview.getMainAttributes().get("Logging Profile"));
+        Assert.assertFalse("Log file's preview should not be empty", logFilePreview.preview().isEmpty());
+    }
 }

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/undertow/SessionOperationsTest.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/undertow/SessionOperationsTest.java
@@ -19,6 +19,7 @@ import org.jboss.hal.testsuite.Console;
 import org.jboss.hal.testsuite.Random;
 import org.jboss.hal.testsuite.creaper.ManagementClientProvider;
 import org.jboss.hal.testsuite.page.runtime.UndertowRuntimePage;
+import org.jboss.hal.testsuite.test.DeploymentDrone;
 import org.jboss.hal.testsuite.test.configuration.undertow.UndertowFixtures;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;

--- a/tests/basic/src/test/resources/org/jboss/hal/testsuite/test/runtime/logging/pom.xml
+++ b/tests/basic/src/test/resources/org/jboss/hal/testsuite/test/runtime/logging/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project 
+  xmlns="http://maven.apache.org/POM/4.0.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.jboss.hal</groupId>
+  <artifactId>logging-profiles-demo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>war</packaging>
+  <name>HAL Logging profiles demo</name>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <loggingProfile>custom</loggingProfile>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <version.server.bom>15.0.0.Beta1</version.server.bom>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-javaee8-with-tools</artifactId>
+        <version>${version.server.bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <archive>
+            <index>true</index>
+            <manifestEntries>
+              <Logging-Profile>${loggingProfile}</Logging-Profile>
+            </manifestEntries>
+          </archive>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/basic/src/test/resources/org/jboss/hal/testsuite/test/runtime/logging/src/main/java/org/jboss/hal/logging/profile/demo/LoggingExample.java
+++ b/tests/basic/src/test/resources/org/jboss/hal/testsuite/test/runtime/logging/src/main/java/org/jboss/hal/logging/profile/demo/LoggingExample.java
@@ -1,0 +1,28 @@
+package org.jboss.hal.logging.profile.demo;
+
+import org.jboss.logging.Logger;
+
+public class LoggingExample {
+    
+    private static final Logger logger = Logger.getLogger(LoggingExample.class);
+
+public static void logDebug() {
+    logger.debug("DEBUG");
+}
+public static void logError() {
+    logger.error("ERROR");
+}
+public static void logFatal() {
+    logger.fatal("FATAL");
+}
+public static void logInfo() {
+    logger.info("INFO");
+}
+public static void logTrace() {
+    logger.trace("TRACE");
+}
+public static void logWarn() {
+    logger.warn("WARN");
+}
+
+}

--- a/tests/basic/src/test/resources/org/jboss/hal/testsuite/test/runtime/logging/src/main/webapp/home.jsp
+++ b/tests/basic/src/test/resources/org/jboss/hal/testsuite/test/runtime/logging/src/main/webapp/home.jsp
@@ -1,0 +1,37 @@
+<%--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+--%>
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@ page import="org.jboss.hal.logging.profile.demo.LoggingExample" %>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Logging Quickstart</title>
+</head>
+<body>
+<%
+LoggingExample.logDebug();
+LoggingExample.logError();
+LoggingExample.logFatal();
+LoggingExample.logInfo();
+LoggingExample.logTrace();
+LoggingExample.logWarn();
+%>
+Log Messages have been written.  Please check your log files.
+</body>
+</html>

--- a/tests/basic/src/test/resources/org/jboss/hal/testsuite/test/runtime/logging/src/main/webapp/index.html
+++ b/tests/basic/src/test/resources/org/jboss/hal/testsuite/test/runtime/logging/src/main/webapp/index.html
@@ -1,0 +1,23 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Plain HTML page that kicks us into the app -->
+
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; URL=home.jsp">
+</head>
+</html>


### PR DESCRIPTION
Description: If only https is enabled the admin console shows no server url at Runtime -> Hosts -> <Host name> -> <Server name>.

There is a filter for socket bindings with a name started with http in org.jboss.hal.core.runtime.server.ServerUrlTasks which takes the first such binding regardless it is bound (enabled) or not, see [1]. This then leads to n/a at line 128, see [2].

[https://issues.jboss.org/browse/WFLY-12115](https://issues.jboss.org/browse/WFLY-12115)