### PR TITLE
[Hal 1576] - Add BusyWorkerThreadCount metric in IO WorkerPreview

### DIFF
--- a/common/src/main/java/org/jboss/hal/testsuite/fragment/finder/IOWorkerPreviewFragment.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/fragment/finder/IOWorkerPreviewFragment.java
@@ -37,6 +37,9 @@ public class IOWorkerPreviewFragment {
     @FindByJQuery("div.progress-description[title='IO Thread Count'] + div")
     private WebElement ioThreadCount;
 
+    @FindByJQuery("div.progress-description[title='Busy Task Thread Count'] + div")
+    private WebElement busyTaskThreadCount;
+
     @FindByJQuery("a.clickable > span.fa-refresh")
     private WebElement refreshButton;
 
@@ -54,6 +57,10 @@ public class IOWorkerPreviewFragment {
 
     public WebElement getIoThreadCount() {
         return ioThreadCount;
+    }
+
+    public WebElement getBusyTaskThreadCount() {
+        return busyTaskThreadCount;
     }
 
     public void refresh() {

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/io/IOWorkerTest.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/io/IOWorkerTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.wildfly.extras.creaper.core.CommandFailedException;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
@@ -89,6 +90,24 @@ public class IOWorkerTest {
     @Before
     public void initConsole() {
         browser.navigate().refresh();
+    }
+
+    /**
+     * Test is BusyTaskThreadCount is displayed.
+     * See https://issues.jboss.org/browse/HAL-1576
+     * @throws IOException
+     */
+    @Test
+    public void checkDisplayOfBusyTaskTreadCount() throws IOException {
+        IOWorkerPreviewFragment ioWorkerPreviewFragment = getIOWorkerFragment().preview(IOWorkerPreviewFragment.class);
+     try {
+         IOWorkerPreviewFragment.ProgressItem busyTaskTreadCount =
+                 new IOWorkerPreviewFragment.ProgressItem(ioWorkerPreviewFragment.getBusyTaskThreadCount());
+         busyTaskTreadCount.getCurrentValue();
+
+     } catch (NoSuchElementException e) {
+         Assert.fail("No number of busy threads is displayed. See HAL-1576.");
+     }
     }
 
     @Test


### PR DESCRIPTION
Description: WFCORE-3333 exposed a number of busy threads in the task worker thread pool in JBoss CLI. Add the metric under IO Worker Runtime in the management console.

Jira issue:[https://issues.jboss.org/browse/HAL-1576](https://issues.jboss.org/browse/HAL-1576)