### PR TITLE
Element names changed

### DIFF
--- a/common/src/main/java/org/jboss/hal/testsuite/fragment/HeaderFragment.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/fragment/HeaderFragment.java
@@ -35,7 +35,7 @@ public class HeaderFragment {
     @FindBy(css = "." + drawerPf + "." + drawerPfHal) private NotificationDrawerFragment notificationDrawer;
     @FindBy(css = "ul[data-element=topLevelCategories] > li > a") private List<WebElement> topLevelCategories;
     @FindBy(css = "ul[data-element=topLevelCategories] > li.active > a") private WebElement selectedTopLevelCategory;
-    @FindBy(css = "ol[data-element=breadcrumb]") private HeaderBreadcrumbFragment breadcrumb;
+    @FindBy(css = "ol.breadcrumb") private HeaderBreadcrumbFragment breadcrumb;
 
     public NotificationDrawerFragment openNotificationDrawer() {
         notifications.click();

--- a/common/src/main/java/org/jboss/hal/testsuite/page/HomePage.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/page/HomePage.java
@@ -38,7 +38,7 @@ import static org.jboss.hal.testsuite.Selectors.contains;
 @Place(NameTokens.HOMEPAGE)
 public class HomePage extends BasePage {
 
-    private static final String MODULES_SELECTOR = "a[data-element=moduleHeader]";
+    private static final String MODULES_SELECTOR = "div.navbar-header";
     @FindBy(css = MODULES_SELECTOR) private List<WebElement> modules;
     @FindBy(id = Ids.HEADER_USERNAME) private WebElement userElement;
 


### PR DESCRIPTION
Some tests crash because of incorrect names of expected elements. So far, this MR isn't fixing the issue with missing "hal-root-container", which causes the majority of test failures right now.