### PR TITLE
[HAL-1750] - Web Console returning WFLYCTL0030: No resource definition is registered for address

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The testsuite uses various profiles to decide how and which tests to run. The fo
 
 - `chrome` | `firefox` | `safari`: Defines the browser to run the tests (mutual exclusive)
 - `basic`, `rbac`, `transaction`, `multihosts`, `keycloak`: Defines which tests to run (can be combined)
-- `standalone` | `domain`: Defines the operation mode (mutual exclusive)
+- `standalone` | `domain` | `domain-hc-dc`: Defines the operation mode (mutual exclusive)
 
 Combine multiple profiles to define your setup. Choose at least one profile from each line. Please note that you cannot combine profiles which are marked as mutual exclusive.
 
@@ -18,6 +18,7 @@ Examples of valid combinations:
 
 - `chrome,basic,standalone`
 - `firefox,basic,rbac,domain`
+- `firefox,basic,domain-hc-dc`
 - `safari,rbac,transaction,standalone`
 
 Examples of invalid combinations:
@@ -25,6 +26,8 @@ Examples of invalid combinations:
 - `safari,firefox`
 - `basic,transaction`
 - `standalone,domain`
+- `standalone,domain-hc-dc`
+- `domain,domain-hc-dc`
 - `chrome,basic,standalone,domain`
 
 ## Run Tests

--- a/common/src/main/java/org/jboss/hal/testsuite/category/DomainHcDc.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/category/DomainHcDc.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015-2021 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.hal.testsuite.category;
+
+public interface DomainHcDc {
+}

--- a/common/src/main/java/org/jboss/hal/testsuite/fragment/finder/HostsPreviewFragment.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/fragment/finder/HostsPreviewFragment.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2021 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.hal.testsuite.fragment.finder;
+
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.fragment.Root;
+import org.jboss.hal.testsuite.Console;
+import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import static org.jboss.arquillian.graphene.Graphene.waitGui;
+
+public class HostsPreviewFragment {
+    @Drone
+    private WebDriver browser;
+    @Root
+    private WebElement root;
+    @Inject
+    private Console console;
+
+
+    private boolean isPresent(By selector) {
+        try {
+            waitGui().until().element(root, selector).is().present();
+        } catch (TimeoutException e) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/common/src/main/java/org/jboss/hal/testsuite/page/runtime/HostsPage.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/page/runtime/HostsPage.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015-2021 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.hal.testsuite.page.runtime;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.hal.meta.token.NameTokens;
+import org.jboss.hal.testsuite.fragment.finder.FinderPath;
+import org.jboss.hal.testsuite.fragment.finder.HostsPreviewFragment;
+import org.jboss.hal.testsuite.page.BasePage;
+import org.jboss.hal.testsuite.page.Place;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.jboss.arquillian.graphene.Graphene.waitGui;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.HOST;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.HOSTS;
+import static org.jboss.hal.resources.Ids.DOMAIN_BROWSE_BY;
+
+
+@Place(NameTokens.RUNTIME)
+public class HostsPage extends BasePage {
+    public static final String MAIN_SERVER_GROUP = "main-server-group";
+
+    @FindBy(id = "server") private WebElement serverElement;
+    @FindBy(id = "rss") private WebElement rssElement;
+    @FindBy(id = "undertow-runtime-deployment-column") private WebElement undertowRuntimeDeploymentColumn;
+    @FindBy(id = "hal-finder-preview") private WebElement halFinderPreview;
+
+    @Override
+    public void navigate() {
+        console.finder(NameTokens.RUNTIME, new FinderPath().append(DOMAIN_BROWSE_BY, HOSTS)).column(HOST);
+    }
+
+    public HostsPreviewFragment navigateToHostsFragment() {
+        return navigateAndReturnHostsFragment();
+    }
+
+    private HostsPreviewFragment navigateAndReturnHostsFragment() {
+        return console.finder(NameTokens.RUNTIME, new FinderPath().append(DOMAIN_BROWSE_BY, HOSTS))
+                .preview(HostsPreviewFragment.class);
+    }
+
+    /**
+     * Return all hosts (Webelemets) from  address Runtime > Hosts
+     * @return
+     */
+    public List<WebElement> getHostsItems() {
+        return browser.findElement(By.id("host")).findElement(By.className("pinnable")).findElements(By.className("item-text"));
+    }
+
+    /**
+     * Wait for load Server view (Runtime > Hosts > HC > Server) and return it as WebElement
+     * @return
+     */
+    public WebElement getServerElement() {
+        waitGui().until().element(serverElement).is().visible();
+        return serverElement;
+    }
+
+    /**
+     * Wait for load Monitor view (Runtime > Hosts > HC > Server > Monitor) and return it as WebElemnt
+     * This webelement is displayed as Monitor fragment but has id set to rss.
+     * @return
+     */
+    public WebElement getRssElement() {
+        waitGui().until().element(rssElement).is().visible();
+        return rssElement;
+    }
+
+    /**
+     * Wait for load view with info about deployed application (Runtime > Hosts > HC > Server > Monitor > Web > Deployment > deployed application) and return it as WebElement
+     * @return
+     */
+    public WebElement getHalFinderPreview() {
+        waitGui().until().element(halFinderPreview).is().visible();
+        return halFinderPreview;
+    }
+
+    /**
+     * Wait for load Deployment view  (Runtime > Hosts > HC > Server > Monitor > Web > Deployment) and return it as Webelement
+     * @return
+     */
+    public WebElement getUndertowRuntimeDeploymentColumn() {
+        waitGui().until().element(undertowRuntimeDeploymentColumn).is().visible();
+        return  undertowRuntimeDeploymentColumn;
+    }
+
+
+
+    /**
+     * Go to Runtime > Hosts > HC host > server-one > Web (Undertow) > Deployment
+     */
+    public void goToDeploymentOnHcServer() throws InterruptedException {
+        getHostsItems().get(1).click();
+
+        WebElement localServerelement = getServerElement();
+        //Sometimes page is displayed but no server is loaded so we need reload
+        if (localServerelement.findElements(By.className("item-text")).isEmpty()) {
+            localServerelement.findElement(By.id("server-refresh")).click();
+            TimeUnit.SECONDS.sleep(1);
+        }
+        waitGui().until().element(localServerelement.findElement(By.className("pinnable")).findElement(By.cssSelector("small[title=\"" + MAIN_SERVER_GROUP + "\"]"))).is().visible();
+        localServerelement.findElement(By.className("pinnable")).findElement(By.cssSelector("small[title=\"" + MAIN_SERVER_GROUP + "\"]")).click();
+        waitGui().until().element(By.id("undertow"));
+        getRssElement().findElement(By.id("undertow")).click();
+        browser.findElement(By.id("undertow-runtime")).findElement(By.id("deployment")).click();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -446,6 +446,21 @@
             </properties>
         </profile>
         <profile>
+            <id>domain-hc-dc</id>
+            <properties>
+                <suite.mode>domain</suite.mode>
+                <test.included.category>
+                    org.jboss.hal.testsuite.category.DomainHcDc
+                </test.included.category>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-domain-remote</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>upstream</id>
             <properties>
                 <upstream.excluded.category>
@@ -485,7 +500,7 @@
         <repository>
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Maven Repository Group</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/hosts/NoResourceDefinitionTestCase.java
+++ b/tests/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/hosts/NoResourceDefinitionTestCase.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015-2021 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Petr Adamec
+ */
+package org.jboss.hal.testsuite.test.runtime.hosts;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.page.Page;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.hal.testsuite.Console;
+import org.jboss.hal.testsuite.category.DomainHcDc;
+import org.jboss.hal.testsuite.creaper.ManagementClientProvider;
+import org.jboss.hal.testsuite.page.runtime.HostsPage;
+import org.jboss.hal.testsuite.test.deployment.Deployment;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.wildfly.extras.creaper.commands.deployments.Undeploy;
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+
+@RunWith(Arquillian.class)
+@Category(DomainHcDc.class)
+public class NoResourceDefinitionTestCase {
+    private static final String TEMP_DEPLOYMENT =
+            "temp-deployment-" + RandomStringUtils.randomAlphanumeric(7) + ".war";
+    private static final OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient();
+    @Page private HostsPage page;
+    @Inject private Console console;
+    @Drone protected WebDriver browser;
+
+
+    private static final Operations operations = new Operations(client);
+
+
+    @BeforeClass
+    public static void deploy() throws CommandFailedException {
+        Deployment deployment = new Deployment.Builder(TEMP_DEPLOYMENT)
+                .textFile("index.html", "<h1>HAL to rule them all</h1>")
+                .build();
+
+        client.apply(deployment.deployEnabledCommand(HostsPage.MAIN_SERVER_GROUP));
+    }
+
+    @AfterClass
+    public static void tearDown() throws IOException, OperationException, CommandFailedException {
+        client.apply(new Undeploy.Builder(TEMP_DEPLOYMENT).build());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        page.navigate();
+    }
+
+    /**
+     * Test for https://issues.redhat.com/browse/HAL-1750.
+     * Test if error is displayed after click on deploy application in Runtime > Hosts > HC host > server-one > Web (Undertow) > Deployment
+     * @throws IOException
+     */
+    @Test
+    public void noResourceDefinition() throws IOException, InterruptedException {
+        page.goToDeploymentOnHcServer();
+        WebElement element = page.getUndertowRuntimeDeploymentColumn();
+        element.findElement(By.id(TEMP_DEPLOYMENT.replace(".","").toLowerCase())).click();
+        page.getHalFinderPreview();
+        Assert.assertTrue("No resource definition ... For more information see HAL-1750", console.verifyNoError());
+
+    }
+
+}


### PR DESCRIPTION
Title: Web Console returning WFLYCTL0030: No resource definition is registered for address
Description:
The trick to reproduce is to have a DC and an and additional HC. This issue is not reproducible when the Undertow -> Deployment tab is reached out from the DC, for example, master HC.
The problem is not on the server-side, it was verified manually that running the operation via CLI works without any issue. It seems a problem derived from how HAL mounts the address to access to Deployment tab when the tab is reached out from the HC which is not the DC.

Jira issue : [https://issues.redhat.com/browse/HAL-1750](https://issues.redhat.com/browse/HAL-1750)

