### PR TITLE
Test for HAL-1757

### DIFF
--- a/tests-configuration-infinispan/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/cache/container/CacheViewTest.java
+++ b/tests-configuration-infinispan/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/cache/container/CacheViewTest.java
@@ -47,14 +47,17 @@ public class CacheViewTest {
     }
 
     /**
-     *Check if internal error is displayed when click on view on cache.
-     * See https://issues.redhat.com/browse/HAL-1627
+     * Check if Missing metadatain resource description and then
+     * check if internal error is displayed when click on view on cache.
+     * See https://issues.redhat.com/browse/HAL-1757, https://issues.redhat.com/browse/HAL-1627
      */
     @Test
     public void checkNoErrorTest() {
         List<WebElement> elements =  cacheColumn.getItems();
         elements.get(0).click();
         elements.get(0).findElement(By.className("clickable")).click();
+        console.verifyError();
+        Assert.assertTrue("Missing metadata... For more information see https://issues.redhat.com/browse/HAL-1757", console.verifyNoError());
         waitGui().until().element(By.className("back")).is().visible();
         Assert.assertTrue("Internal error is displayed! See https://issues.redhat.com/browse/HAL-1627",
                 console.verifyNoError());


### PR DESCRIPTION
[HAL-1757] - Missing metadata: [resource description] @ {selected.profile}/subsystem=infinispan/cache-container=*/distributed-cache=*/memory=binary

Description: When try to view details any type of cache in cache container the following error message appear:
Missing metadata: [resource description] @ {selected.profile}/subsystem=infinispan/cache-container=*/distributed-cache=*/memory=binary

Jira issue: [HAL-1757](https://issues.redhat.com/browse/HAL-1757)