### PR TITLE
[HAL-1760] - Add test for credential reference edit testing. Add meth…

### DIFF
--- a/common/src/main/java/org/jboss/hal/testsuite/page/configuration/MailPage.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/page/configuration/MailPage.java
@@ -24,7 +24,7 @@ import org.jboss.hal.testsuite.page.BasePage;
 import org.jboss.hal.testsuite.page.Place;
 import org.openqa.selenium.support.FindBy;
 
-import static org.jboss.hal.dmr.ModelDescriptionConstants.CREDENTIAL_REFERENCE;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
 import static org.jboss.hal.testsuite.Selectors.WRAPPER;
 
 @Place(NameTokens.MAIL_SESSION)
@@ -54,5 +54,22 @@ public class MailPage extends BasePage {
 
     public FormFragment getMailServerCrForm() {
         return mailServerCrForm;
+    }
+
+    /**
+     * Navigate to SMTP in mail session
+     * navigate to Configuration > Subsystem > Mail > Mail Session > "mailSession" > Server > SMTP
+     * @param mailSession name of mail session. If is null or empty String  <i>default<i/> is used.
+     */
+    public void navigateToSMTP(String mailSession) {
+        if (mailSession == null || mailSession.isEmpty()) {
+            mailSession = "default";
+        }
+        navigate(NAME, mailSession);
+        console.waitNoNotification();
+        console.verticalNavigation().selectPrimary(Ids.MAIL_SERVER_ITEM);
+        getMailServerTabs().select(Ids.build(Ids.MAIL_SERVER, CREDENTIAL_REFERENCE, Ids.TAB));
+        getMailServerTable().select(SMTP.toUpperCase());
+        console.waitNoNotification();
     }
 }

--- a/tests-configuration-mail/src/test/java/org/jboss/hal/testsuite/test/configuration/mail/MailServerCredRefUpdateTest.java
+++ b/tests-configuration-mail/src/test/java/org/jboss/hal/testsuite/test/configuration/mail/MailServerCredRefUpdateTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015-2022 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.hal.testsuite.test.configuration.mail;
+
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.graphene.page.Page;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.hal.resources.Ids;
+import org.jboss.hal.testsuite.Console;
+import org.jboss.hal.testsuite.Random;
+import org.jboss.hal.testsuite.creaper.ManagementClientProvider;
+import org.jboss.hal.testsuite.page.configuration.MailPage;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+
+import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
+
+/**
+ * @author Petr Adamec
+ */
+@RunWith(Arquillian.class)
+public class MailServerCredRefUpdateTest {
+
+    private static final OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient();
+    private static final Administration administration = new Administration(client);
+
+    @After
+    public void clear() throws Exception {
+        page.getMailServerCrForm().remove();
+        administration.reload();
+    }
+
+    @Inject private Console console;
+    @Page private MailPage page;
+
+
+    /**
+     * The first navigate browser to Configuration > Subsystem > Mail > Mail Session > default > Server > SMTP
+     * Then create credential reference with empty store and alias. Only clear-text will set (random value).
+     * @throws Exception During reload console can be thrown Exception.
+     */
+    @Before
+    public void setUp() throws Exception {
+        //navigate to Configuration > Subsystem > Mail > Mail Session > default > Server > SMTP
+        page.navigateToSMTP("default");
+
+        //Create credential resource with random value in CLEAR_TEXT. Other attributes will be empty
+        page.getMailServerCrForm().getRoot().findElement(By.className("btn-primary")).click();
+        console.waitNoNotification();
+        console.addResourceDialog().getForm().text(CLEAR_TEXT, Random.name());
+        console.addResourceDialog().add();
+        console.waitNoNotification();
+        administration.reload();
+    }
+
+
+    /**
+     * Test if <i>credential reference<i/> (only with <i>>clear-text<i/ set) can be update like erase <i>clear-text<i/> and set <i>store<i/> and <i>alias<i/>.
+     * Test for <a href="https://issues.redhat.com/browse/HAL-1760">HAL-1760</a>
+     */
+    @Test
+    public void eraseClearTextAndSetStoreAndAlias() {
+        String store = Ids.build(STORE, Random.name());
+        String alias = Ids.build(ALIAS, Random.name());
+        page.getMailServerCrForm().edit();
+        page.getMailServerCrForm().text(STORE, store);
+        page.getMailServerCrForm().text(ALIAS, alias);
+        page.getMailServerCrForm().text(CLEAR_TEXT, "");
+        page.getMailServerCrForm().save();
+        Assert.assertTrue("Test can't update credential reference with empty CLEAR_TEXT -  maybe due to HAL-1760. ", console.verifyNoError());
+    }
+
+}


### PR DESCRIPTION
Upstream issue: [HAL-1760 - Editing credential reference for mail server is not working](https://issues.redhat.com/browse/JBEAP-22744)

Description issue: User is not able to change credential reference attribute for mail server. In order to change credential reference attribute, user has to either fill the clear-tex*t attribute, or set *alias and store attributes. Unfortunately, when he tries to do so, he is greeted with an error notification. This may be caused for management operations underneath. 

Link to test run: [https://main-jenkins-csb-eapcpqe.apps.ocp4.prod.psi.redhat.com/job/eap-74x-hal-3-basic-standalone/15/](https://main-jenkins-csb-eapcpqe.apps.ocp4.prod.psi.redhat.com/job/eap-74x-hal-3-basic-standalone/15/)

Pull request contains test for [this issue](https://issues.redhat.com/browse/JBEAP-22744) and one added method to MailPage class for other navigate.

