### PR TITLE
[HAL-1848] - Disabled datasource throws error in Runtime

### DIFF
--- a/common/src/main/java/org/jboss/hal/testsuite/page/runtime/DataSourceRuntimePage.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/page/runtime/DataSourceRuntimePage.java
@@ -1,0 +1,56 @@
+package org.jboss.hal.testsuite.page.runtime;
+
+import java.io.IOException;
+
+import org.jboss.hal.meta.token.NameTokens;
+import org.jboss.hal.resources.Ids;
+import org.jboss.hal.testsuite.creaper.ManagementClientProvider;
+import org.jboss.hal.testsuite.page.BasePage;
+import org.jboss.hal.testsuite.page.Place;
+import org.jboss.hal.testsuite.util.ServerEnvironmentUtils;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+
+
+
+import static org.jboss.arquillian.graphene.Graphene.waitGui;
+
+@Place(NameTokens.RUNTIME)
+public class DataSourceRuntimePage extends BasePage {
+    private static final OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient();
+    private static final ServerEnvironmentUtils serverEnvironmentUtils = new ServerEnvironmentUtils(client);
+
+
+    @FindBy(id = "datasources") private WebElement datasources;
+
+    @FindBy(id = Ids.DATA_SOURCE_RUNTIME) private WebElement dataSourceRuntime;
+
+    @Override
+    public void navigate()  {
+       super.navigate();
+        try {
+            console.finder(NameTokens.RUNTIME).column(Ids.STANDALONE_SERVER_COLUMN)
+                     .selectItem("standalone-host-" + serverEnvironmentUtils.getServerHostName());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    /**
+     * Wait for load  list of Datasource view  (Runtime > Server > Monitor > Datasources) and return it as WebElement
+     * @return
+     */
+    public WebElement getDatasource() {
+        waitGui().until().element(datasources).is().visible();
+        return datasources;
+    }
+
+    /**
+     * Wait for load Datasource view (Runtime > Server > Monitor > Datasources -> Datasource view) and return it as WebElement
+     * @return
+     */
+    public WebElement getDataSourceRuntime() {
+        waitGui().until().element(dataSourceRuntime).is().visible();
+        return dataSourceRuntime;
+    }
+}

--- a/tests-hal-runtime/src/test/java/org/jboss/hal/testsuite/test/runtime/DisabledDataSourceTest.java
+++ b/tests-hal-runtime/src/test/java/org/jboss/hal/testsuite/test/runtime/DisabledDataSourceTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2015-2023 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.hal.testsuite.test.runtime;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.page.Page;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.hal.testsuite.Console;
+import org.jboss.hal.testsuite.category.Standalone;
+import org.jboss.hal.testsuite.creaper.ManagementClientProvider;
+import org.jboss.hal.testsuite.page.runtime.DataSourceRuntimePage;
+import org.jboss.hal.testsuite.util.ServerEnvironmentUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+import org.wildfly.extras.creaper.commands.foundation.online.SnapshotBackup;
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.online.CliException;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+
+
+/**
+ * @author <a href="mailto:padamec@redhat.com">Petr Adamec</a>
+ */
+@RunWith(Arquillian.class)
+@Category(Standalone.class)
+public class DisabledDataSourceTest {
+    private static final OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient();
+    private static final ServerEnvironmentUtils serverEnvironmentUtils = new ServerEnvironmentUtils(client);
+    protected static final Administration administration = new Administration(client);
+
+    @AfterClass
+    public static void cleanUp() throws IOException {
+        client.close();
+    }
+
+    @Drone
+    private WebDriver browser;
+
+    @Inject
+    private Console console;
+
+    @Page
+    private DataSourceRuntimePage page;
+
+    private SnapshotBackup snapshot = new SnapshotBackup();
+
+    @Before
+    public void before() throws CommandFailedException, IOException, CliException, InterruptedException, TimeoutException {
+        client.apply(snapshot.backup());
+        client.executeCli("/subsystem=datasources/data-source=ExampleDS:disable");
+        administration.reloadIfRequired();
+        page.navigate();
+        page.getDatasource().click();
+    }
+
+    @After
+    public void restoreBackup() throws IOException, InterruptedException, TimeoutException, CommandFailedException {
+        client.apply(snapshot.restore());
+        administration.reloadIfRequired();
+
+    }
+
+    /**
+     * Test if error is thrown when datasource is disabled and click on Runtime > Server > Datasources.
+     * For more information look at HAL-1848
+     * @throws IOException
+     */
+    @Test
+    public void testDisabledDatasourceThrowsError() throws IOException {
+        page.getDataSourceRuntime();
+        Assert.assertTrue("Internal error is displayed! See https://issues.redhat.com/browse/HAL-1848",
+                console.verifyNoError());
+    }
+}


### PR DESCRIPTION
Issue: Disabled datasource throws error in Runtime
Description: 
When a datasource is disabled visiting Runtime > Host/Server > Datasources fails because of unavailable statistics (there is a check that depends on a certain child to be present), we normally offer an action to "View" the datasource but this displays a page with a detailed statistics and that doesn't make sense when there's nothing to read even if statistics is enabled.

Jira Issue: [https://issues.redhat.com/browse/HAL-1848](https://issues.redhat.com/browse/HAL-1848)

Here si link to test run [https://cp-jenkins.eapqe.psi.redhat.com/view/EAP-74x/view/EAP-74x-Web-Console/job/eap-74x-hal-3-basic-standalone/39/](https://cp-jenkins.eapqe.psi.redhat.com/view/EAP-74x/view/EAP-74x-Web-Console/job/eap-74x-hal-3-basic-standalone/39/)