### PR TITLE
exclude commons-io from org.jboss.arquillian.graphene from dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,12 @@
                 <groupId>org.jboss.arquillian.graphene</groupId>
                 <artifactId>arquillian-browser-screenshooter</artifactId>
                 <version>${graphene.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-io</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.arquillian</groupId>


### PR DESCRIPTION
Using wrong commons-io library version causes compilation error

`[ERROR] /home/hudson/hudson_workspace/workspace/eap-74x-webconsole-basic-prepare/webconsole-testsuite/tests/keycloak/src/test/java/org/jboss/hal/testsuite/test/keycloak/KeycloakOperations.java:[158,36] no suitable method found for toString(java.io.InputStream,java.nio.charset.Charset)
11:55:46 [ERROR]     method org.apache.commons.io.IOUtils.toString(java.io.InputStream,java.lang.String) is not applicable
11:55:46 [ERROR]       (argument mismatch; java.nio.charset.Charset cannot be converted to java.lang.String)
11:55:46 [ERROR]     method org.apache.commons.io.IOUtils.toString(byte[],java.lang.String) is not applicable
11:55:46 [ERROR]       (argument mismatch; java.io.InputStream cannot be converted to byte[])`

Test run: https://cp-jenkins.eapqe.psi.redhat.com/job/eap-74x-webconsole-basic-prepare/80/