### PR TITLE
HAL-1920 part 2: Fixing ManagementOperationsTest.cancelNonProgressingOperation

### DIFF
--- a/tests-configuration-management/src/test/java/org/jboss/hal/testsuite/test/configuration/management/operations/ManagementOperationsTest.java
+++ b/tests-configuration-management/src/test/java/org/jboss/hal/testsuite/test/configuration/management/operations/ManagementOperationsTest.java
@@ -100,7 +100,7 @@ public class ManagementOperationsTest {
         page.navigate();
         managementOps.waitForNonProgressingOperation(25);
         page.cancelNonProgressingOperation();
-        assertTrue(managementOps.thereIsNoNonProgressingOperationATM());
+        assertTrue(managementOps.areNonProgressiveOperationsCancelledATM());
 
         deployFuture.join();
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/HAL-1920

There is a wrong assumption in the test that cancelled operations are no longer listed. Such operations can be listed, but should be marked as cancelled. This fix changes the original assumption accordingly.