### PR TITLE
Fix ManagementOperationsTest#cancelOperation for negative IDs

### DIFF
--- a/common/src/main/java/org/jboss/hal/testsuite/page/runtime/ManagementOperationsPage.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/page/runtime/ManagementOperationsPage.java
@@ -30,7 +30,7 @@ public class ManagementOperationsPage extends BasePage {
         WebElement cancelButton = getRootContainer().findElement(cancelButtonSelector);
         cancelButton.click();
         console.confirmationDialog().confirm();
-        Graphene.waitGui().until().element(By.id(Ids.ACTIVE_OPERATION + "-" + operationId)).text().contains("Cancelled: true");
+        Graphene.waitGui().until().element(By.id(activeOperationId)).text().contains("Cancelled: true");
 
         return this;
     }


### PR DESCRIPTION
Negative IDs usually appears on JDK 17. Tested locally.