### PR TITLE
HAL-1882: Fix testsuite.next build failure caused by commons-io transitive dependencies (backport from master)

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -89,6 +89,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,15 @@
                 <groupId>org.jboss.arquillian.graphene</groupId>
                 <artifactId>arquillian-browser-screenshooter</artifactId>
                 <version>${graphene.version}</version>
+                <exclusions>
+                    <!-- https://issues.sonatype.org/browse/MVNCENTRAL-244
+                        The artifact is in the depency tree with the correct group id thanks to other dependencies.
+                        We manange the version of commons-io:commons-io in this pom.xml -->
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-io</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.arquillian</groupId>

--- a/tests-configuration-management/pom.xml
+++ b/tests-configuration-management/pom.xml
@@ -58,6 +58,10 @@
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-cli</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/tests-configuration-undertow/pom.xml
+++ b/tests-configuration-undertow/pom.xml
@@ -54,6 +54,10 @@
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-cli</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/tests/keycloak/pom.xml
+++ b/tests/keycloak/pom.xml
@@ -36,4 +36,11 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
https://issues.redhat.com/browse/HAL-1882
Backport of https://github.com/hal/testsuite.next/pull/187.