### PR TITLE
HAL-1882: Fix testsuite.next build failure caused by commons-io transitive dependencies (backport)

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -90,6 +90,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,15 @@
                 <groupId>org.jboss.arquillian.graphene</groupId>
                 <artifactId>arquillian-browser-screenshooter</artifactId>
                 <version>${graphene.version}</version>
+                <exclusions>
+                    <!-- https://issues.sonatype.org/browse/MVNCENTRAL-244
+                        The artifact is in the depency tree with the correct group id thanks to other dependencies.
+                        We manange the version of commons-io:commons-io in this pom.xml -->
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-io</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.arquillian</groupId>

--- a/tests/keycloak/pom.xml
+++ b/tests/keycloak/pom.xml
@@ -37,4 +37,11 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
https://issues.redhat.com/browse/HAL-1882
Backport of #187 