### PR TITLE
[EAPQE-3195] LdapRealmTest, SecurityRealmsTest, SslSettingsTest and StoresSettingsTest fixed due to the nested attributes changes

### DIFF
--- a/tests-configuration-elytron/src/test/java/org/jboss/hal/testsuite/test/configuration/elytron/LdapRealmTest.java
+++ b/tests-configuration-elytron/src/test/java/org/jboss/hal/testsuite/test/configuration/elytron/LdapRealmTest.java
@@ -177,7 +177,7 @@ public class LdapRealmTest {
         crud.create(ldapRealmAddress(LDAP_RLM_CREATE), table, f -> {
             f.text(NAME, LDAP_RLM_CREATE);
             f.text(DIR_CONTEXT, DIR_UPDATE);
-            f.text(RDN_IDENTIFIER, ANY_STRING);
+            f.text(IDENTITY_MAPPING + RDN_IDENTIFIER, ANY_STRING);
         });
     }
 
@@ -187,7 +187,7 @@ public class LdapRealmTest {
         TableFragment table = page.getLdapRealmTable();
         crud.createWithErrorAndCancelDialog(table, f -> {
             f.text(NAME, LDAP_RLM_CREATE);
-            f.text(RDN_IDENTIFIER, ANY_STRING);
+            f.text(IDENTITY_MAPPING + RDN_IDENTIFIER, ANY_STRING);
         }, DIR_CONTEXT);
     }
 

--- a/tests-configuration-elytron/src/test/java/org/jboss/hal/testsuite/test/configuration/elytron/SecurityRealmsTest.java
+++ b/tests-configuration-elytron/src/test/java/org/jboss/hal/testsuite/test/configuration/elytron/SecurityRealmsTest.java
@@ -532,8 +532,8 @@ public class SecurityRealmsTest {
 
         crud.create(propertiesRealmAddress(PROP_RLM_CREATE), table, f -> {
             f.text(NAME, PROP_RLM_CREATE);
-            f.text(PATH, APP_USERS_PROPS);
-            f.text(RELATIVE_TO, JBOSS_SRV_CONFIG_DIR);
+            f.text(USERS_PROPERTIES + PATH, APP_USERS_PROPS);
+            f.text(USERS_PROPERTIES + RELATIVE_TO, JBOSS_SRV_CONFIG_DIR);
         });
     }
 
@@ -541,7 +541,7 @@ public class SecurityRealmsTest {
     public void propertiesRealmTryCreate() throws Exception {
         console.verticalNavigation().selectSecondary(SECURITY_REALM_ITEM, PROPERTIES_REALM_ITEM);
         TableFragment table = page.getPropertiesRealmTable();
-        crud.createWithErrorAndCancelDialog(table, f -> f.text(NAME, PROP_RLM_CREATE), PATH);
+        crud.createWithErrorAndCancelDialog(table, f -> f.text(NAME, PROP_RLM_CREATE), USERS_PROPERTIES + PATH);
     }
 
     @Test

--- a/tests-configuration-elytron/src/test/java/org/jboss/hal/testsuite/test/configuration/elytron/other/settings/SslSettingsTest.java
+++ b/tests-configuration-elytron/src/test/java/org/jboss/hal/testsuite/test/configuration/elytron/other/settings/SslSettingsTest.java
@@ -176,7 +176,7 @@ public class SslSettingsTest extends AbstractOtherSettingsTest {
         crud.create(keyManagerAddress(KEY_MAN_CREATE), table, f -> {
             f.text(NAME, KEY_MAN_CREATE);
             f.text(KEY_STORE, KEY_ST_UPDATE);
-            f.text(CLEAR_TEXT, ANY_STRING);
+            f.text(CREDENTIAL_REFERENCE + CLEAR_TEXT, ANY_STRING);
         });
     }
 

--- a/tests-configuration-elytron/src/test/java/org/jboss/hal/testsuite/test/configuration/elytron/other/settings/StoresSettingsTest.java
+++ b/tests-configuration-elytron/src/test/java/org/jboss/hal/testsuite/test/configuration/elytron/other/settings/StoresSettingsTest.java
@@ -91,7 +91,7 @@ public class StoresSettingsTest extends AbstractOtherSettingsTest {
             f.text(NAME, CRED_ST_CREATE);
             f.text(PATH, ANY_STRING);
             f.flip(CREATE, true);
-            f.text(CLEAR_TEXT, ANY_STRING);
+            f.text(CREDENTIAL_REFERENCE + CLEAR_TEXT, ANY_STRING);
         });
     }
 
@@ -103,7 +103,7 @@ public class StoresSettingsTest extends AbstractOtherSettingsTest {
         crud.createWithErrorAndCancelDialog(table, f -> {
             f.text(NAME, CRED_ST_CREATE);
             f.flip(CREATE, true);
-        }, CLEAR_TEXT);
+        }, CREDENTIAL_REFERENCE + CLEAR_TEXT);
     }
 
     @Test
@@ -191,7 +191,7 @@ public class StoresSettingsTest extends AbstractOtherSettingsTest {
         crud.create(keyStoreAddress(KEY_ST_CREATE), table, f -> {
             f.text(NAME, KEY_ST_CREATE);
             f.text(TYPE, JKS);
-            f.text(CLEAR_TEXT, ANY_STRING);
+            f.text(CREDENTIAL_REFERENCE + CLEAR_TEXT, ANY_STRING);
         });
     }
 
@@ -200,7 +200,7 @@ public class StoresSettingsTest extends AbstractOtherSettingsTest {
         console.verticalNavigation().selectSecondary(STORES_ITEM, KEY_STORE_ITEM);
         TableFragment table = page.getKeyStoreTable();
 
-        crud.createWithErrorAndCancelDialog(table, f -> f.text(NAME, KEY_ST_CREATE), CLEAR_TEXT);
+        crud.createWithErrorAndCancelDialog(table, f -> f.text(NAME, KEY_ST_CREATE), CREDENTIAL_REFERENCE + CLEAR_TEXT);
     }
 
     @Test


### PR DESCRIPTION
Due to changes in several attribute names in the Add pop-ups (see [comment on JBEAP-29197](https://issues.redhat.com/browse/JBEAP-29197?focusedId=26517104&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-26517104)  there are dots added and some of the web console upstream tests related to those forms started to fail.
The affected tests are:

- LdapRealmTest.create
- LdapRealmTest.tryCreate
- SecurityRealmsTest.propertiesRealmCreate
- SecurityRealmsTest.propertiesRealmTryCreate
- SslSettingsTest.keyManagerCreate
- StoresSettingsTest.credentialStoreCreate
- StoresSettingsTest.credentialStoreTryCreate
- StoresSettingsTest.keyStoreCreate
- StoresSettingsTest.keyStoreTryCreate