### PR TITLE
Clear text attribute fixed for the SingleSignOnAddTest.create

### DIFF
--- a/tests-configuration-undertow/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/application/security/domain/SingleSignOnAddTest.java
+++ b/tests-configuration-undertow/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/application/security/domain/SingleSignOnAddTest.java
@@ -86,7 +86,7 @@ public class SingleSignOnAddTest {
             page.getSingleSignOnForm(), formFragment -> {
                 formFragment.text(ApplicationSecurityDomainFixtures.SINGLE_SIGN_ON_KEY_ALIAS, keyAlias);
                 formFragment.text(ApplicationSecurityDomainFixtures.SINGLE_SIGN_ON_KEY_STORE, KEY_STORE_TO_BE_ADDED);
-                formFragment.text(ElytronFixtures.CREDENTIAL_REFERENCE_CLEAR_TEXT, clearTextValue);
+                formFragment.text(ElytronFixtures.CREDENTIAL_REFERENCE + ElytronFixtures.CREDENTIAL_REFERENCE_CLEAR_TEXT, clearTextValue);
             }, resourceVerifier -> {
                 resourceVerifier.verifyAttribute(ApplicationSecurityDomainFixtures.SINGLE_SIGN_ON_KEY_ALIAS, keyAlias);
                 resourceVerifier.verifyAttribute(ApplicationSecurityDomainFixtures.SINGLE_SIGN_ON_KEY_STORE,


### PR DESCRIPTION
Due to changes in several attribute names in the Add pop-ups (see [comment on JBEAP-29197](https://issues.redhat.com/browse/JBEAP-29197?focusedId=26517104&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-26517104) there are dots added and the SingleSignOnAddTest.create started to fail.