### PR TITLE
[EAPQE-5552] Updating default value of queue-requests-on-start in Undertow AttributesTest

### DIFF
--- a/tests-configuration-undertow/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/server/hosts/AttributesTest.java
+++ b/tests-configuration-undertow/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/server/hosts/AttributesTest.java
@@ -111,7 +111,8 @@ public class AttributesTest {
     public void toggleQueueRequestsOnStart() throws Exception {
         String attrName = "queue-requests-on-start";
         FormFragment form = page.getHostsForm();
-        boolean originalValue = operations.readAttribute(UNDERTOW_DEFAULT_HOST_ADDRESS, attrName).booleanValue();
+        // Boolean attributes with undefined default value and undefined value are displayed as false by default
+        boolean originalValue = operations.readAttribute(UNDERTOW_DEFAULT_HOST_ADDRESS, attrName).booleanValue(false);
         assertEquals("The '" + attrName + "' value presented in the form differs from the one in model.",
                 originalValue, Boolean.valueOf(form.value(attrName)));
         crudOperations.update(UNDERTOW_DEFAULT_HOST_ADDRESS, form, attrName, !originalValue);


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/EAPQE-5552

Backport of commit https://github.com/hal/testsuite.next/pull/223/changes/916790f9a70f1d5bfcebcd695bec055a0293c5b9 
